### PR TITLE
Remove all kolla-ansible dependencies

### DIFF
--- a/doc/source/deployment-guide.rst
+++ b/doc/source/deployment-guide.rst
@@ -139,6 +139,8 @@ the following work-around::
     curl -L  https://github.com/sbezverk/kubelet--45613/raw/master/kubelet.gz | gzip -d > /usr/bin/kubelet
     chmod +x /usr/bin/kubelet
 
+As an alternative, Kubernetes 1.6.4 has been used and appears to work without any patch required.
+
 
 Ubuntu
 ------
@@ -356,21 +358,17 @@ Install repositories necessary to install packaging::
        mkdir kolla-bringup
        cd kolla-bringup
 
-Clone kolla-ansible::
-
-    git clone http://github.com/openstack/kolla-ansible
-
 Clone kolla-kubernetes::
 
     git clone http://github.com/openstack/kolla-kubernetes
 
-Install kolla-ansible and kolla-kubernetes::
+Install kolla-kubernetes::
 
-    sudo pip install -U kolla-ansible/ kolla-kubernetes/
+    sudo pip install -U kolla-kubernetes/
 
 Copy default Kolla configuration to /etc::
 
-    sudo cp -aR /usr/share/kolla-ansible/etc_examples/kolla /etc
+    sudo cp -aR /usr/share/kolla-kubernetes/etc_examples/kolla /etc
 
 Copy default kolla-kubernetes configuration to /etc::
 
@@ -467,7 +465,13 @@ QEMU libvirt functionality and enable a workaround for a bug in libvirt::
 
 Generate the default configuration::
 
-    sudo kolla-ansible genconfig
+    sudo ansible-playbook \
+      -e ansible_python_interpreter=/usr/bin/python \
+      -e @/etc/kolla/globals.yml \
+      -e @/etc/kolla/passwords.yml \
+      -e CONFIG_DIR=/etc/kolla \
+      ./kolla-kubernetes/ansible/site.yml
+
 
 Generate the Kubernetes secrets and register them with Kubernetes::
 
@@ -476,15 +480,18 @@ Generate the Kubernetes secrets and register them with Kubernetes::
 Create and register the Kolla config maps::
 
     kollakube res create configmap \
-        mariadb keystone horizon rabbitmq memcached nova-api nova-conductor \
-        nova-scheduler glance-api-haproxy glance-registry-haproxy glance-api \
-        glance-registry neutron-server neutron-dhcp-agent neutron-l3-agent \
-        neutron-metadata-agent neutron-openvswitch-agent openvswitch-db-server \
-        openvswitch-vswitchd nova-libvirt nova-compute nova-consoleauth \
-        nova-novncproxy nova-novncproxy-haproxy neutron-server-haproxy \
-        nova-api-haproxy cinder-api cinder-api-haproxy cinder-backup \
-        cinder-scheduler cinder-volume iscsid tgtd keepalived \
-        placement-api placement-api-haproxy
+      mariadb \
+      rabbitmq memcached keystone \
+      iscsid tgtd keepalived \
+      cinder-api cinder-api-haproxy cinder-backup cinder-scheduler cinder-volume \
+      glance-api-haproxy glance-registry-haproxy glance-api glance-registry \
+      openvswitch-db-server openvswitch-vswitchd \
+      neutron-server neutron-dhcp-agent neutron-l3-agent neutron-metadata-agent \
+        neutron-openvswitch-agent neutron-server-haproxy \
+      nova-api nova-conductor nova-scheduler nova-libvirt nova-compute \
+        nova-consoleauth nova-novncproxy nova-novncproxy-haproxy nova-api-haproxy \
+      placement-api placement-api-haproxy \
+      horizon
 
 Enable resolv.conf workaround::
 
@@ -640,11 +647,18 @@ Start many of the remaining service level charts::
     helm install --debug kolla-kubernetes/helm/service/nova-control --namespace kolla --name nova-control --values ./cloud.yaml
     helm install --debug kolla-kubernetes/helm/service/nova-compute --namespace kolla --name nova-compute --values ./cloud.yaml
 
-Wait for nova-compute to enter into Running state before creating the cell0
-database::
+Previously, one was required to wait for nova-compute to enter into Running
+state and then create two jobs manually for VM (cell) placement. Those jobs
+are now automatically created by the above helm invocations. Use this
+opportunity to verify that these jobs are properly running on Kubernetes::
 
-    helm install --debug kolla-kubernetes/helm/microservice/nova-cell0-create-db-job --namespace kolla --name nova-cell0-create-db-job --values ./cloud.yaml
-    helm install --debug kolla-kubernetes/helm/microservice/nova-api-create-simple-cell-job --namespace kolla --name nova-api-create-simple-cell --values ./cloud.yaml
+    kubectl --namespace=kolla get job/nova-cell0-create-db job/nova-api-create-cell
+
+Output should resemble::
+
+    NAME                   DESIRED   SUCCESSFUL   AGE
+    nova-cell0-create-db   1         1            14m
+    nova-api-create-cell   1         1            9m
 
 Deploy iSCSI support with Cinder LVM (Optional)
 
@@ -702,7 +716,7 @@ Install OpenStack clients::
 
 Bootstrap the cloud environment and create a VM as requested::
 
-    kolla-ansible/tools/init-runonce
+    kolla-kubernetes/tools/init-runonce
 
 Create a floating IP address and add to the VM::
 

--- a/tools/init-runonce
+++ b/tools/init-runonce
@@ -1,0 +1,130 @@
+#!/bin/bash
+#
+# This script is meant to be run once after running start for the first
+# time.  This script downloads a cirros image and registers it.  Then it
+# configures networking and nova quotas to allow 40 m1.small instances
+# to be created.
+
+IMAGE_URL=http://download.cirros-cloud.net/0.3.5/
+IMAGE=cirros-0.3.5-x86_64-disk.img
+IMAGE_NAME=cirros
+IMAGE_TYPE=linux
+EXT_NET_CIDR='10.0.2.0/24'
+EXT_NET_RANGE='start=10.0.2.150,end=10.0.2.199'
+EXT_NET_GATEWAY='10.0.2.1'
+
+# Sanitize language settings to avoid commands bailing out
+# with "unsupported locale setting" errors.
+unset LANG
+unset LANGUAGE
+LC_ALL=C
+export LC_ALL
+for i in curl openstack; do
+    if [[ ! $(type ${i} 2>/dev/null) ]]; then
+        if [ "${i}" == 'curl' ]; then
+            echo "Please install ${i} before proceeding"
+        else
+            echo "Please install python-${i}client before proceeding"
+        fi
+        exit
+    fi
+done
+# Move to top level directory
+REAL_PATH=$(python -c "import os,sys;print os.path.realpath('$0')")
+cd "$(dirname "$REAL_PATH")/.."
+
+# Test for credentials set
+if [[ "${OS_USERNAME}" == "" ]]; then
+    echo "No Keystone credentials specified.  Try running source openrc"
+    exit
+fi
+
+# Test to ensure configure script is run only once
+if openstack image list | grep -q cirros; then
+    echo "This tool should only be run once per deployment."
+    exit
+fi
+
+echo Downloading glance image.
+if ! [ -f "${IMAGE}" ]; then
+    curl -L -o ./${IMAGE} ${IMAGE_URL}/${IMAGE}
+fi
+echo Creating glance image.
+openstack image create --disk-format qcow2 --container-format bare --public \
+    --property os_type=${IMAGE_TYPE} --file ./${IMAGE} ${IMAGE_NAME}
+
+echo Configuring neutron.
+openstack network create --external --provider-physical-network physnet1 \
+    --provider-network-type flat public1
+openstack subnet create --no-dhcp \
+    --allocation-pool ${EXT_NET_RANGE} --network public1 \
+    --subnet-range ${EXT_NET_CIDR} --gateway ${EXT_NET_GATEWAY} public1-subnet
+
+openstack network create --provider-network-type vxlan demo-net
+openstack subnet create --subnet-range 10.0.0.0/24 --network demo-net \
+    --gateway 10.0.0.1 --dns-nameserver 8.8.8.8 demo-subnet
+
+openstack router create demo-router
+openstack router add subnet demo-router demo-subnet
+openstack router set --external-gateway public1 demo-router
+
+# Get admin user and tenant IDs
+ADMIN_USER_ID=$(openstack user list | awk '/ admin / {print $2}')
+ADMIN_PROJECT_ID=$(openstack project list | awk '/ admin / {print $2}')
+ADMIN_SEC_GROUP=$(openstack security group list --project ${ADMIN_PROJECT_ID} | awk '/ default / {print $2}')
+
+# Sec Group Config
+openstack security group rule create --ingress --ethertype IPv4 \
+    --protocol icmp ${ADMIN_SEC_GROUP} 
+openstack security group rule create --ingress --ethertype IPv4 \
+    --protocol tcp --dst-port 22 ${ADMIN_SEC_GROUP}
+# Open heat-cfn so it can run on a different host
+openstack security group rule create --ingress --ethertype IPv4 \
+    --protocol tcp --dst-port 8000 ${ADMIN_SEC_GROUP}
+openstack security group rule create --ingress --ethertype IPv4 \
+    --protocol tcp --dst-port 8080 ${ADMIN_SEC_GROUP}
+
+if [ ! -f ~/.ssh/id_rsa.pub ]; then
+    echo Generating ssh key.
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa
+fi
+if [ -r ~/.ssh/id_rsa.pub ]; then
+    echo Configuring nova public key and quotas.
+    openstack keypair create --public-key ~/.ssh/id_rsa.pub mykey
+fi
+
+# Increase the quota to allow 40 m1.small instances to be created
+
+# 40 instances
+openstack quota set --instances 40 ${ADMIN_PROJECT_ID}
+
+# 40 cores
+openstack quota set --cores 40 ${ADMIN_PROJECT_ID}
+
+# 96GB ram
+openstack quota set --ram 96000 ${ADMIN_PROJECT_ID}
+
+# add default flavors, if they don't already exist
+if ! openstack flavor list | grep -q m1.tiny; then
+    openstack flavor create --id 1 --ram 512 --disk 1 --vcpus 1 m1.tiny
+    openstack flavor create --id 2 --ram 2048 --disk 20 --vcpus 1 m1.small
+    openstack flavor create --id 3 --ram 4096 --disk 40 --vcpus 2 m1.medium
+    openstack flavor create --id 4 --ram 8192 --disk 80 --vcpus 4 m1.large
+    openstack flavor create --id 5 --ram 16384 --disk 160 --vcpus 8 m1.xlarge
+fi
+
+DEMO_NET_ID=$(openstack network list | awk '/ demo-net / {print $2}')
+
+cat << EOF
+
+Done.
+
+To deploy a demo instance, run:
+
+openstack server create \\
+    --image ${IMAGE_NAME} \\
+    --flavor m1.tiny \\
+    --key-name mykey \\
+    --nic net-id=${DEMO_NET_ID} \\
+    demo1
+EOF


### PR DESCRIPTION
See ticket https://bugs.launchpad.net/kolla-kubernetes/+bug/1693281.
The kolla-ansible project has deprecated ml2_conf.ini for several of the
Neutron microservices. This is a breaking change with the
kolla-kubernetes deployment guide. This commit updates the guide to
remove all kolla-ansible dependencies and installs the single
kolla-ansible tool required for the baremetal deployment to work.